### PR TITLE
Add Serilog.Extensions.Logging to core project

### DIFF
--- a/src/FileRelay.Core/FileRelay.Core.csproj
+++ b/src/FileRelay.Core/FileRelay.Core.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.24" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />


### PR DESCRIPTION
## Summary
- add Serilog.Extensions.Logging package reference to FileRelay.Core to align with the UI project

## Testing
- dotnet restore FileRelay.sln *(fails: command not found)*
- dotnet build FileRelay.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df858888108328a539103a72e328f4