### PR TITLE
Ensure UI window shows on startup

### DIFF
--- a/src/FileRelay.Core/FileRelay.Core.csproj
+++ b/src/FileRelay.Core/FileRelay.Core.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.24" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />

--- a/src/FileRelay.UI/App.xaml
+++ b/src/FileRelay.UI/App.xaml
@@ -1,7 +1,6 @@
 <Application x:Class="FileRelay.UI.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/FileRelay.UI/App.xaml.cs
+++ b/src/FileRelay.UI/App.xaml.cs
@@ -4,4 +4,12 @@ namespace FileRelay.UI;
 
 public partial class App : Application
 {
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+
+        var mainWindow = new MainWindow();
+        MainWindow = mainWindow;
+        mainWindow.Show();
+    }
 }


### PR DESCRIPTION
## Summary
- remove the XAML StartupUri and manually launch MainWindow when the application starts
- ensure the application sets and shows its main window during startup to make the UI visible

## Testing
- dotnet restore FileRelay.sln *(fails: command not found)*
- dotnet build FileRelay.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df858888108328a539103a72e328f4