### PR TITLE
Set FileRelay UI project output type to WinExe

### DIFF
--- a/src/FileRelay.UI/FileRelay.UI.csproj
+++ b/src/FileRelay.UI/FileRelay.UI.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- set the FileRelay UI project output type to WinExe to ensure a Windows executable is produced

## Testing
- dotnet build FileRelay.sln *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df902368708328aff4925a532a25b2