### PR TITLE
Handle missing status sources safely

### DIFF
--- a/src/FileRelay.UI/ViewModels/MainViewModel.cs
+++ b/src/FileRelay.UI/ViewModels/MainViewModel.cs
@@ -171,9 +171,10 @@ public partial class MainViewModel : ObservableObject
     {
         Sources.Clear();
         var credentialNames = _configuration.Credentials.ToDictionary(c => c.Id, c => $"{c.Domain}\\{c.Username}");
+        var statusSources = status?.Sources ?? Enumerable.Empty<SourceStatus>();
         foreach (var source in _configuration.Sources)
         {
-            var statusItem = status?.Sources.FirstOrDefault(s => s.Id == source.Id);
+            var statusItem = statusSources.FirstOrDefault(s => s.Id == source.Id);
             var vm = SourceItemViewModel.FromConfiguration(source, statusItem?.LastActivityUtc, statusItem?.TargetCount ?? 0);
             foreach (var target in vm.Targets)
             {


### PR DESCRIPTION
## Summary
- add a local fallback sequence for runtime status sources
- reuse the fallback when finding matching source status entries

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df988cba8083289ada5c5884893ed9