### PR TITLE
Ensure log loading occurs on dispatcher thread

### DIFF
--- a/src/FileRelay.UI/ViewModels/MainViewModel.cs
+++ b/src/FileRelay.UI/ViewModels/MainViewModel.cs
@@ -55,8 +55,20 @@ public partial class MainViewModel : ObservableObject
             _configuration = configuration;
         }
 
-        Application.Current?.Dispatcher.Invoke(() => UpdateSources(status));
-        LoadLogs();
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher?.CheckAccess() == true)
+        {
+            UpdateSources(status);
+            LoadLogs();
+        }
+        else
+        {
+            dispatcher?.Invoke(() =>
+            {
+                UpdateSources(status);
+                LoadLogs();
+            });
+        }
     }
 
     [RelayCommand]
@@ -221,7 +233,15 @@ public partial class MainViewModel : ObservableObject
 
     partial void OnSelectedLogLevelFilterChanged(string value)
     {
-        LoadLogs();
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher?.CheckAccess() == true)
+        {
+            LoadLogs();
+        }
+        else
+        {
+            dispatcher?.Invoke(LoadLogs);
+        }
     }
 
     private static bool TryParseLog(string line, out LogEntryViewModel entry)


### PR DESCRIPTION
## Summary
- ensure RefreshAsync marshals source and log updates to the dispatcher thread
- guard log filter change handling by invoking LoadLogs on the dispatcher when required

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df9bf552e0832891159b131ff35e61