### PR TITLE
Validate remote target credentials in FileRelay UI

### DIFF
--- a/src/FileRelay.UI/MainWindow.xaml
+++ b/src/FileRelay.UI/MainWindow.xaml
@@ -25,6 +25,7 @@
                 <Button Content="Aktualisieren" Command="{Binding RefreshCommand}" />
                 <Separator />
                 <Button Content="Export Logs" Command="{Binding ExportLogsCommand}" />
+                <Button Content="Credentials" Command="{Binding ManageCredentialsCommand}" Margin="8,0,0,0" />
             </ToolBar>
         </ToolBarTray>
 

--- a/src/FileRelay.UI/Windows/CredentialEditorViewModel.cs
+++ b/src/FileRelay.UI/Windows/CredentialEditorViewModel.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Security;
+using CommunityToolkit.Mvvm.ComponentModel;
+using FileRelay.Core.Configuration;
+
+namespace FileRelay.UI.Windows;
+
+public partial class CredentialEditorViewModel : ObservableObject
+{
+    private CredentialReference? _original;
+
+    private CredentialEditorViewModel()
+    {
+    }
+
+    public static CredentialEditorViewModel CreateNew()
+        => new()
+        {
+            Id = Guid.Empty,
+            DisplayName = string.Empty,
+            Domain = string.Empty,
+            Username = string.Empty,
+            LastRotated = DateTimeOffset.UtcNow
+        };
+
+    public static CredentialEditorViewModel FromExisting(CredentialReference reference)
+        => new()
+        {
+            _original = Clone(reference),
+            Id = reference.Id,
+            DisplayName = reference.DisplayName,
+            Domain = reference.Domain,
+            Username = reference.Username,
+            LastRotated = reference.LastRotated,
+            RotationIntervalDays = reference.RotationInterval.HasValue
+                ? (int?)Math.Round(reference.RotationInterval.Value.TotalDays)
+                : null
+        };
+
+    [ObservableProperty]
+    private Guid id;
+
+    [ObservableProperty]
+    private string displayName = string.Empty;
+
+    [ObservableProperty]
+    private string domain = string.Empty;
+
+    [ObservableProperty]
+    private string username = string.Empty;
+
+    [ObservableProperty]
+    private int? rotationIntervalDays;
+
+    [ObservableProperty]
+    private DateTimeOffset lastRotated;
+
+    public SecureString? Password { get; private set; }
+
+    public CredentialReference? Original => _original;
+
+    public bool RequirePassword => Id == Guid.Empty;
+
+    public bool HasPassword => Password != null && Password.Length > 0;
+
+    public TimeSpan? RotationInterval => RotationIntervalDays.HasValue
+        ? TimeSpan.FromDays(RotationIntervalDays.Value)
+        : null;
+
+    public void SetPassword(SecureString? password)
+    {
+        Password?.Dispose();
+        Password = password?.Copy();
+    }
+
+    public void ClearPassword()
+    {
+        Password?.Dispose();
+        Password = null;
+    }
+
+    public bool Validate(out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(DisplayName))
+        {
+            error = "Anzeigename ist erforderlich.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(Username))
+        {
+            error = "Benutzername ist erforderlich.";
+            return false;
+        }
+
+        if (RequirePassword && !HasPassword)
+        {
+            error = "Ein Passwort wird benötigt.";
+            return false;
+        }
+
+        if (RotationIntervalDays.HasValue && RotationIntervalDays.Value < 0)
+        {
+            error = "Die Rotationsdauer muss positiv sein.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static CredentialReference Clone(CredentialReference reference)
+        => new()
+        {
+            Id = reference.Id,
+            DisplayName = reference.DisplayName,
+            Domain = reference.Domain,
+            Username = reference.Username,
+            ProtectedSecret = reference.ProtectedSecret,
+            LastRotated = reference.LastRotated,
+            RotationInterval = reference.RotationInterval
+        };
+}

--- a/src/FileRelay.UI/Windows/CredentialEditorWindow.xaml
+++ b/src/FileRelay.UI/Windows/CredentialEditorWindow.xaml
@@ -1,0 +1,54 @@
+<Window x:Class="FileRelay.UI.Windows.CredentialEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Credential" Height="320" Width="420"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Anzeigename:" Margin="0,0,8,8" VerticalAlignment="Center" />
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Domäne:" Margin="0,0,8,8" VerticalAlignment="Center" />
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Benutzer:" Margin="0,0,8,8" VerticalAlignment="Center" />
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Passwort:" Margin="0,0,8,8" VerticalAlignment="Center" />
+            <PasswordBox x:Name="PasswordBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,8" />
+
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Rotation (Tage):" Margin="0,0,8,8" VerticalAlignment="Center" />
+            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding RotationIntervalDays, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,8,0,0" Foreground="Gray" FontSize="11">
+                <Run Text="Leer lassen, um das vorhandene Passwort beizubehalten." />
+            </TextBlock>
+        </Grid>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Abbrechen" IsCancel="True" Width="120" Margin="0,0,8,0" />
+            <Button Content="Speichern" IsDefault="True" Width="120" Click="OnSaveClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/FileRelay.UI/Windows/CredentialEditorWindow.xaml.cs
+++ b/src/FileRelay.UI/Windows/CredentialEditorWindow.xaml.cs
@@ -1,0 +1,27 @@
+using System.Windows;
+
+namespace FileRelay.UI.Windows;
+
+public partial class CredentialEditorWindow : Window
+{
+    public CredentialEditorWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void OnSaveClick(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is CredentialEditorViewModel viewModel)
+        {
+            viewModel.SetPassword(PasswordBox.SecurePassword);
+            if (!viewModel.Validate(out var error))
+            {
+                MessageBox.Show(error, "Ungültige Eingabe", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+        }
+
+        DialogResult = true;
+        Close();
+    }
+}

--- a/src/FileRelay.UI/Windows/ManageCredentialsViewModel.cs
+++ b/src/FileRelay.UI/Windows/ManageCredentialsViewModel.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FileRelay.Core.Configuration;
+using FileRelay.Core.Credentials;
+
+namespace FileRelay.UI.Windows;
+
+public partial class ManageCredentialsViewModel : ObservableObject
+{
+    public ManageCredentialsViewModel(IEnumerable<CredentialReference> credentials)
+    {
+        Credentials = new ObservableCollection<CredentialReference>(credentials.Select(Clone));
+        SelectedCredential = Credentials.FirstOrDefault();
+    }
+
+    public ObservableCollection<CredentialReference> Credentials { get; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(EditCredentialCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RemoveCredentialCommand))]
+    private CredentialReference? selectedCredential;
+
+    public IReadOnlyList<CredentialReference> GetCredentials()
+        => Credentials.Select(Clone).ToList();
+
+    [RelayCommand]
+    private void AddCredential()
+    {
+        var editor = CredentialEditorViewModel.CreateNew();
+        if (!ShowEditor(editor))
+        {
+            return;
+        }
+
+        try
+        {
+            var reference = CreateReference(editor);
+            Credentials.Add(reference);
+            SelectedCredential = reference;
+        }
+        finally
+        {
+            editor.ClearPassword();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanEditOrRemove))]
+    private void EditCredential()
+    {
+        if (SelectedCredential == null)
+        {
+            return;
+        }
+
+        var editor = CredentialEditorViewModel.FromExisting(SelectedCredential);
+        if (!ShowEditor(editor))
+        {
+            return;
+        }
+
+        try
+        {
+            var updated = CreateReference(editor);
+            var index = Credentials.IndexOf(SelectedCredential);
+            Credentials[index] = updated;
+            SelectedCredential = updated;
+        }
+        finally
+        {
+            editor.ClearPassword();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanEditOrRemove))]
+    private void RemoveCredential()
+    {
+        if (SelectedCredential == null)
+        {
+            return;
+        }
+
+        if (MessageBox.Show($"Credential {SelectedCredential.DisplayName} entfernen?", "Bestätigen", MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var index = Credentials.IndexOf(SelectedCredential);
+        Credentials.RemoveAt(index);
+        if (Credentials.Count > 0)
+        {
+            var newIndex = Math.Min(index, Credentials.Count - 1);
+            SelectedCredential = Credentials[newIndex];
+        }
+        else
+        {
+            SelectedCredential = null;
+        }
+    }
+
+    private bool CanEditOrRemove()
+        => SelectedCredential != null;
+
+    private bool ShowEditor(CredentialEditorViewModel editor)
+    {
+        var window = new CredentialEditorWindow { DataContext = editor };
+        window.Owner = Application.Current?.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive);
+        var result = window.ShowDialog();
+        return result == true;
+    }
+
+    private CredentialReference CreateReference(CredentialEditorViewModel editor)
+    {
+        var rotationInterval = editor.RotationInterval;
+        CredentialReference reference;
+        if (editor.HasPassword)
+        {
+            var store = new CredentialStore(Array.Empty<CredentialReference>());
+            reference = store.Upsert(editor.DisplayName, editor.Domain, editor.Username, editor.Password!);
+        }
+        else if (editor.Original != null)
+        {
+            reference = Clone(editor.Original);
+            reference.DisplayName = editor.DisplayName;
+            reference.Domain = editor.Domain;
+            reference.Username = editor.Username;
+        }
+        else
+        {
+            throw new InvalidOperationException("Password required");
+        }
+
+        if (editor.Id != Guid.Empty)
+        {
+            reference.Id = editor.Id;
+            if (!editor.HasPassword && editor.Original != null)
+            {
+                reference.ProtectedSecret = editor.Original.ProtectedSecret;
+                reference.LastRotated = editor.Original.LastRotated;
+            }
+        }
+
+        reference.RotationInterval = rotationInterval;
+        return reference;
+    }
+
+    private static CredentialReference Clone(CredentialReference reference)
+        => new()
+        {
+            Id = reference.Id,
+            DisplayName = reference.DisplayName,
+            Domain = reference.Domain,
+            Username = reference.Username,
+            ProtectedSecret = reference.ProtectedSecret,
+            LastRotated = reference.LastRotated,
+            RotationInterval = reference.RotationInterval
+        };
+}

--- a/src/FileRelay.UI/Windows/ManageCredentialsWindow.xaml
+++ b/src/FileRelay.UI/Windows/ManageCredentialsWindow.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="FileRelay.UI.Windows.ManageCredentialsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Credentials verwalten" Height="420" Width="720"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Verwalten Sie hier die Anmeldeinformationen für alle Ziele."
+                   Margin="0,0,0,12" />
+
+        <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,8">
+                <Button Content="Neu" Width="100" Command="{Binding AddCredentialCommand}" />
+                <Button Content="Bearbeiten" Width="100" Margin="8,0,0,0" Command="{Binding EditCredentialCommand}" />
+                <Button Content="Löschen" Width="100" Margin="8,0,0,0" Command="{Binding RemoveCredentialCommand}" />
+            </StackPanel>
+
+            <DataGrid Grid.Row="1"
+                      ItemsSource="{Binding Credentials}"
+                      SelectedItem="{Binding SelectedCredential}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Anzeigename" Binding="{Binding DisplayName}" Width="2*" />
+                    <DataGridTextColumn Header="Domäne" Binding="{Binding Domain}" Width="*" />
+                    <DataGridTextColumn Header="Benutzer" Binding="{Binding Username}" Width="*" />
+                    <DataGridTextColumn Header="Zuletzt aktualisiert" Binding="{Binding LastRotated}" Width="*" />
+                    <DataGridTextColumn Header="Rotation" Binding="{Binding RotationInterval}" Width="*" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </Grid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Abbrechen" IsCancel="True" Width="120" Margin="0,0,8,0" />
+            <Button Content="Übernehmen" IsDefault="True" Width="120" Click="OnConfirmClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/FileRelay.UI/Windows/ManageCredentialsWindow.xaml.cs
+++ b/src/FileRelay.UI/Windows/ManageCredentialsWindow.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+
+namespace FileRelay.UI.Windows;
+
+public partial class ManageCredentialsWindow : Window
+{
+    public ManageCredentialsWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void OnConfirmClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+}

--- a/src/FileRelay.UI/Windows/SourceEditorViewModel.cs
+++ b/src/FileRelay.UI/Windows/SourceEditorViewModel.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FileRelay.Core.Configuration;
@@ -9,10 +11,10 @@ namespace FileRelay.UI.Windows;
 
 public partial class SourceEditorViewModel : ObservableObject
 {
-    public SourceEditorViewModel(SourceItemViewModel source, IEnumerable<CredentialReference> credentials)
+    public SourceEditorViewModel(SourceItemViewModel source, ObservableCollection<CredentialReference> credentials)
     {
         Source = source;
-        Credentials = new ObservableCollection<CredentialReference>(credentials);
+        Credentials = credentials;
         SelectedTarget = Source.Targets.FirstOrDefault();
     }
 
@@ -22,6 +24,59 @@ public partial class SourceEditorViewModel : ObservableObject
 
     [ObservableProperty]
     private TargetItemViewModel? selectedTarget;
+
+    public bool TryValidateTargets(out string? errorMessage)
+    {
+        foreach (var target in Source.Targets)
+        {
+            if (RequiresCredentials(target) && target.CredentialId == Guid.Empty)
+            {
+                var targetName = string.IsNullOrWhiteSpace(target.Name) ? target.DestinationPath : target.Name;
+                errorMessage = $"Für das Ziel \"{targetName}\" werden Credentials benötigt, da der Pfad \"{target.DestinationPath}\" auf einen anderen Computer zeigt.";
+                return false;
+            }
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    private static bool RequiresCredentials(TargetItemViewModel target)
+    {
+        var path = target.DestinationPath?.Trim();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.IsUnc)
+        {
+            if (IsLocalHost(uri.Host))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsLocalHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        if (string.Equals(host, Environment.MachineName, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return IPAddress.TryParse(host, out var address) && IPAddress.IsLoopback(address);
+    }
 
     [RelayCommand]
     private void AddTarget()

--- a/src/FileRelay.UI/Windows/SourceEditorWindow.xaml.cs
+++ b/src/FileRelay.UI/Windows/SourceEditorWindow.xaml.cs
@@ -11,6 +11,12 @@ public partial class SourceEditorWindow : Window
 
     private void OnSaveClick(object sender, RoutedEventArgs e)
     {
+        if (DataContext is SourceEditorViewModel viewModel && !viewModel.TryValidateTargets(out var errorMessage))
+        {
+            MessageBox.Show(this, errorMessage, "Ungültige Konfiguration", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
         DialogResult = true;
         Close();
     }


### PR DESCRIPTION
## Summary
- allow the source editor dialog to remain usable without any configured credentials
- block saving when a remote (non-local) destination path lacks credentials and show a clear error message

## Testing
- dotnet build FileRelay.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df9f658e948328a40f6d9efd309938