### PR TITLE
Broaden local UNC detection in CopyWorker

### DIFF
--- a/src/FileRelay.Core/Copy/CopyWorker.cs
+++ b/src/FileRelay.Core/Copy/CopyWorker.cs
@@ -1,5 +1,12 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using FileRelay.Core.Configuration;
@@ -109,59 +116,65 @@ public sealed class CopyWorker
             return TransferResult.Skipped(request, "SourceMissing");
         }
 
-        var credential = _credentialStore.TryGetDomainCredential(request.Target.CredentialId);
-        if (credential is null)
+        var requiresCredential = RequiresNetworkCredential(request.Target);
+        if (requiresCredential && request.Target.CredentialId == Guid.Empty)
         {
             return TransferResult.AuthError(request, new InvalidOperationException("Credential missing"));
         }
 
-        using (credential)
+        DomainCredential? credential = null;
+        NetworkConnection? connection = null;
+
+        try
         {
-            NetworkConnection? connection = null;
-            try
+            if (requiresCredential)
             {
-                if (IsUncPath(request.Target.DestinationPath))
+                credential = _credentialStore.TryGetDomainCredential(request.Target.CredentialId);
+                if (credential is null)
                 {
-                    connection = new NetworkConnection(GetShareRoot(request.Target.DestinationPath), credential);
-                    connection.Connect();
+                    return TransferResult.AuthError(request, new InvalidOperationException("Credential missing"));
                 }
 
-                var destinationPath = ResolveDestinationPath(request);
-                var destinationDirectory = _fileSystem.Path.GetDirectoryName(destinationPath)!;
-                _fileSystem.Directory.CreateDirectory(destinationDirectory);
-
-                var finalPath = HandleConflict(destinationPath, request.Target.ConflictMode);
-                var tempFile = _fileSystem.Path.Combine(destinationDirectory, $".{_fileSystem.Path.GetFileName(finalPath)}.{Guid.NewGuid():N}.tmp");
-
-                await CopyFileAsync(request.SourceFile, tempFile, cancellationToken).ConfigureAwait(false);
-
-                if (request.Target.VerifyChecksum)
-                {
-                    await VerifyChecksumAsync(request.SourceFile, tempFile, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    VerifySize(request.SourceFile, tempFile);
-                }
-
-                FinalizeCopy(tempFile, finalPath, request.Target.ConflictMode);
-
-                if (request.Source.DeleteAfterCopy)
-                {
-                    DeleteSourceFile(request.SourceFile, request.Source.UseRecycleBin);
-                }
-
-                _logger.LogInformation("Copied {Source} to {Destination}", request.SourceFile, finalPath);
-                return TransferResult.Ok(request);
+                connection = new NetworkConnection(GetShareRoot(request.Target.DestinationPath), credential);
+                connection.Connect();
             }
-            catch (Exception ex)
+
+            var destinationPath = ResolveDestinationPath(request);
+            var destinationDirectory = _fileSystem.Path.GetDirectoryName(destinationPath)!;
+            _fileSystem.Directory.CreateDirectory(destinationDirectory);
+
+            var finalPath = HandleConflict(destinationPath, request.Target.ConflictMode);
+            var tempFile = _fileSystem.Path.Combine(destinationDirectory, $".{_fileSystem.Path.GetFileName(finalPath)}.{Guid.NewGuid():N}.tmp");
+
+            await CopyFileAsync(request.SourceFile, tempFile, cancellationToken).ConfigureAwait(false);
+
+            if (request.Target.VerifyChecksum)
             {
-                return TransferResult.Failure(request, ex);
+                await VerifyChecksumAsync(request.SourceFile, tempFile, cancellationToken).ConfigureAwait(false);
             }
-            finally
+            else
             {
-                connection?.Dispose();
+                VerifySize(request.SourceFile, tempFile);
             }
+
+            FinalizeCopy(tempFile, finalPath, request.Target.ConflictMode);
+
+            if (request.Source.DeleteAfterCopy)
+            {
+                DeleteSourceFile(request.SourceFile, request.Source.UseRecycleBin);
+            }
+
+            _logger.LogInformation("Copied {Source} to {Destination}", request.SourceFile, finalPath);
+            return TransferResult.Ok(request);
+        }
+        catch (Exception ex)
+        {
+            return TransferResult.Failure(request, ex);
+        }
+        finally
+        {
+            connection?.Dispose();
+            credential?.Dispose();
         }
     }
 
@@ -291,5 +304,187 @@ public sealed class CopyWorker
         return index < 0 ? path : path[..index];
     }
 
+    private static readonly Lazy<HashSet<string>> LocalHostNames = new(BuildLocalHostNames, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<HashSet<IPAddress>> LocalAddresses = new(BuildLocalAddresses, LazyThreadSafetyMode.ExecutionAndPublication);
+
     private static bool IsUncPath(string path) => path.StartsWith(@"\\");
+
+    private static bool RequiresNetworkCredential(TargetConfiguration target)
+    {
+        if (!IsUncPath(target.DestinationPath))
+        {
+            return false;
+        }
+
+        var host = GetUncHost(target.DestinationPath);
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        if (IsLocalHost(host))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string? GetUncHost(string path)
+    {
+        if (!IsUncPath(path))
+        {
+            return null;
+        }
+
+        var trimmed = path.TrimStart('\\');
+        var separatorIndex = trimmed.IndexOf('\\');
+        return separatorIndex < 0 ? trimmed : trimmed[..separatorIndex];
+    }
+
+    private static bool IsLocalHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        host = host.TrimEnd('.');
+
+        if (host.Length > 2 && host[0] == '[' && host[^1] == ']')
+        {
+            host = host[1..^1];
+        }
+
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (IPAddress.TryParse(host, out var address))
+        {
+            return IsLocalAddress(address);
+        }
+
+        if (LocalHostNames.Value.Contains(host))
+        {
+            return true;
+        }
+
+        try
+        {
+            var resolved = Dns.GetHostAddresses(host);
+            return resolved.Any(IsLocalAddress);
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ArgumentException)
+        {
+        }
+
+        return false;
+    }
+
+    private static bool IsLocalAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        return LocalAddresses.Value.Contains(address);
+    }
+
+    private static HashSet<string> BuildLocalHostNames()
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void AddIfNotEmpty(string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                result.Add(value.TrimEnd('.'));
+            }
+        }
+
+        AddIfNotEmpty(Environment.MachineName);
+
+        try
+        {
+            AddIfNotEmpty(Dns.GetHostName());
+        }
+        catch (SocketException)
+        {
+        }
+        catch (Exception)
+        {
+        }
+
+        try
+        {
+            var properties = IPGlobalProperties.GetIPGlobalProperties();
+            if (!string.IsNullOrWhiteSpace(properties.DomainName))
+            {
+                AddIfNotEmpty($"{Environment.MachineName}.{properties.DomainName}");
+            }
+        }
+        catch (NetworkInformationException)
+        {
+        }
+        catch (Exception)
+        {
+        }
+
+        return result;
+    }
+
+    private static HashSet<IPAddress> BuildLocalAddresses()
+    {
+        var result = new HashSet<IPAddress>();
+
+        try
+        {
+            var hostName = Dns.GetHostName();
+            foreach (var address in Dns.GetHostAddresses(hostName))
+            {
+                if (address != null)
+                {
+                    result.Add(address);
+                }
+            }
+        }
+        catch (SocketException)
+        {
+        }
+        catch (Exception)
+        {
+        }
+
+        try
+        {
+            foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                foreach (var unicast in networkInterface.GetIPProperties().UnicastAddresses)
+                {
+                    if (unicast.Address != null)
+                    {
+                        result.Add(unicast.Address);
+                    }
+                }
+            }
+        }
+        catch (NetworkInformationException)
+        {
+        }
+        catch (Exception)
+        {
+        }
+
+        result.Add(IPAddress.Loopback);
+        result.Add(IPAddress.IPv6Loopback);
+
+        return result;
+    }
 }

--- a/tests/FileRelay.Tests/CopyWorkerTests.cs
+++ b/tests/FileRelay.Tests/CopyWorkerTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using FileRelay.Core.Configuration;
+using FileRelay.Core.Copy;
+using FileRelay.Core.Credentials;
+using FileRelay.Core.Queue;
+using FileRelay.Core.Watchers;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace FileRelay.Tests;
+
+public class CopyWorkerTests
+{
+    [Fact]
+    public async Task LocalDestinationWithoutCredentialSucceeds()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { @"C:\\source\\file.txt", new MockFileData("content") }
+        });
+
+        var worker = CreateWorker(fileSystem, new CredentialStore(Array.Empty<CredentialReference>()));
+        var source = new SourceConfiguration { Name = "Source", Path = @"C:\\source" };
+        var target = new TargetConfiguration
+        {
+            Name = "Local",
+            DestinationPath = @"C:\\dest",
+            CredentialId = Guid.Empty,
+            VerifyChecksum = false
+        };
+
+        var request = new CopyRequest(source, target, @"C:\\source\\file.txt", "file.txt");
+        var result = await InvokeExecuteCopyAsync(worker, request).ConfigureAwait(false);
+
+        Assert.True(result.Success);
+        Assert.True(fileSystem.FileExists(@"C:\\dest\\file.txt"));
+    }
+
+    [Fact]
+    public async Task RemoteUncWithoutCredentialFailsWithAuthError()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { @"C:\\source\\file.txt", new MockFileData("content") }
+        });
+
+        var worker = CreateWorker(fileSystem, new CredentialStore(Array.Empty<CredentialReference>()));
+        var source = new SourceConfiguration { Name = "Source", Path = @"C:\\source" };
+        var target = new TargetConfiguration
+        {
+            Name = "Remote",
+            DestinationPath = @"\\\\remotehost\\share",
+            CredentialId = Guid.Empty
+        };
+
+        var request = new CopyRequest(source, target, @"C:\\source\\file.txt", "file.txt");
+        var result = await InvokeExecuteCopyAsync(worker, request).ConfigureAwait(false);
+
+        Assert.False(result.Success);
+        Assert.Equal("AuthError", result.Status);
+    }
+
+    [Fact]
+    public void RequiresNetworkCredentialTreatsRegisteredLocalIpAsLocal()
+    {
+        var type = typeof(CopyWorker);
+        var addressesField = type.GetField("LocalAddresses", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var lazy = (Lazy<HashSet<IPAddress>>)addressesField.GetValue(null)!;
+        var addresses = lazy.Value;
+        var customAddress = IPAddress.Parse("192.0.2.55");
+        addresses.Add(customAddress);
+
+        var target = new TargetConfiguration
+        {
+            DestinationPath = $"\\\\{customAddress}\\share"
+        };
+
+        var requires = (bool)type.GetMethod("RequiresNetworkCredential", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, new object[] { target })!;
+
+        Assert.False(requires);
+    }
+
+    private static CopyWorker CreateWorker(IFileSystem fileSystem, CredentialStore credentialStore)
+    {
+        var queue = new CopyQueue();
+        var lockDetector = new FileLockDetector(fileSystem);
+        var options = new GlobalOptions();
+        return new CopyWorker(queue, credentialStore, fileSystem, lockDetector, NullLogger<CopyWorker>.Instance, options);
+    }
+
+    private static Task<TransferResult> InvokeExecuteCopyAsync(CopyWorker worker, CopyRequest request)
+    {
+        var method = typeof(CopyWorker).GetMethod("ExecuteCopyAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task<TransferResult>)method.Invoke(worker, new object[] { request, CancellationToken.None })!;
+    }
+}


### PR DESCRIPTION
## Summary
- expand CopyWorker local-host detection to recognise hostnames, IPv6 literals and interface IPs before demanding credentials
- cache resolved host names and addresses with defensive fallbacks to avoid credential lookups for self-hosted shares
- add a unit test that registers a local IP address and verifies credentials are not required

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa7c9fa608328a479aaec399445bd