### PR TITLE
Handle pipe disposal errors gracefully

### DIFF
--- a/src/FileRelay.Core/Messaging/NamedPipeManagementServer.cs
+++ b/src/FileRelay.Core/Messaging/NamedPipeManagementServer.cs
@@ -47,11 +47,14 @@ public sealed class NamedPipeManagementServer : IAsyncDisposable
                 await using var server = CreatePipeServer();
                 await server.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
 
-                using var reader = new StreamReader(server, Encoding.UTF8, false, leaveOpen: true);
-                using var writer = new StreamWriter(server, Encoding.UTF8, bufferSize: 1024, leaveOpen: true) { AutoFlush = true };
-
                 try
                 {
+                    using var reader = new StreamReader(server, Encoding.UTF8, false, leaveOpen: true);
+                    using var writer = new StreamWriter(server, Encoding.UTF8, bufferSize: 1024, leaveOpen: true)
+                    {
+                        AutoFlush = true
+                    };
+
                     var requestJson = await reader.ReadLineAsync().ConfigureAwait(false);
                     if (requestJson is null)
                     {


### PR DESCRIPTION
## Summary
- ensure the management server's pipe reader and writer are disposed inside the IO try/catch
- prevent broken pipe closures from bubbling up as logged errors when clients disconnect abruptly

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc8c0bb2c832880a5a1ae683a6294