### PR TITLE
Persist default configuration when config file missing

### DIFF
--- a/src/FileRelay.Core/Configuration/ConfigurationService.cs
+++ b/src/FileRelay.Core/Configuration/ConfigurationService.cs
@@ -48,7 +48,9 @@ public sealed class ConfigurationService
             if (!File.Exists(_configurationFile))
             {
                 _logger.LogWarning("Configuration file {File} does not exist. Using defaults.", _configurationFile);
-                return GetCurrent();
+                var defaults = GetCurrent();
+                await SaveAsync(defaults).ConfigureAwait(false);
+                return defaults;
             }
 
             await using var stream = File.OpenRead(_configurationFile);

--- a/tests/FileRelay.Tests/ConfigurationServiceTests.cs
+++ b/tests/FileRelay.Tests/ConfigurationServiceTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FileRelay.Core.Configuration;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace FileRelay.Tests;
+
+public sealed class ConfigurationServiceTests
+{
+    [Fact]
+    public async Task LoadAsync_PersistsDefaultsWhenConfigurationFileMissing()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        var configurationFile = Path.Combine(tempDirectory, "config.json");
+
+        try
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Debug));
+            var logger = loggerFactory.CreateLogger<ConfigurationService>();
+            var service = new ConfigurationService(configurationFile, logger);
+
+            var configuration = await service.LoadAsync().ConfigureAwait(false);
+
+            Assert.NotNull(configuration);
+            Assert.True(File.Exists(configurationFile));
+
+            await using var stream = File.OpenRead(configurationFile);
+            var persisted = await JsonSerializer.DeserializeAsync<AppConfiguration>(stream).ConfigureAwait(false);
+            Assert.NotNull(persisted);
+            Assert.Equal(configuration.Options.ManagementEndpoint, persisted!.Options.ManagementEndpoint);
+            Assert.Equal(configuration.Sources.Count, persisted.Sources.Count);
+            Assert.Equal(configuration.Credentials.Count, persisted.Credentials.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- persist the default configuration file when LoadAsync is called and the file is missing
- add a regression test to verify the configuration file is created on first run

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfca62728883289995fcacd8b40222